### PR TITLE
We should only override console methods before each test

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,12 +65,6 @@ const init = ({ silenceMessage, shouldFailOnWarn = true, shouldFailOnError = tru
   const unexpectedWarnCallStacks = []
 
   let errorMethod, warnMethod
-  if (shouldFailOnError) {
-    errorMethod = patchConsoleMethod('error', unexpectedErrorCallStacks)
-  }
-  if (shouldFailOnWarn) {
-    warnMethod = patchConsoleMethod('warn', unexpectedWarnCallStacks)
-  }
 
   const flushAllUnexpectedConsoleCalls = () => {
     if (shouldFailOnError) {
@@ -84,6 +78,13 @@ const init = ({ silenceMessage, shouldFailOnWarn = true, shouldFailOnError = tru
   }
 
   const resetAllUnexpectedConsoleCalls = () => {
+    if (shouldFailOnError) {
+      errorMethod = patchConsoleMethod('error', unexpectedErrorCallStacks)
+    }
+    if (shouldFailOnWarn) {
+      warnMethod = patchConsoleMethod('warn', unexpectedWarnCallStacks)
+    }
+    
     unexpectedErrorCallStacks.length = 0
     unexpectedWarnCallStacks.length = 0
   }


### PR DESCRIPTION
This fixes the issue where this utility will swallow any console error methods logged outside the test environments. e.g. errors logged BEFORE setup/teardown of Jest tests.