### PR TITLE
Add support for custom error messages (closes #9, closes #11)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,6 +12,12 @@ declare namespace init {
     shouldFailOnError?: boolean
     /** defaults to false */
     shouldFailOnLog?: boolean
+    /**
+     * This function lets you define a custom error message. The methodName is the method
+     * that caused the error, bold is a function that lets you bold subsets of your message.
+     * example: (methodName, bold) => `console.${methodName} is not ${bold('allowed')}`
+     */
+    errorMessage?: (methodName: string, bold: (string) => string) => string
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,18 @@
 const util = require('util')
 const chalk = require('chalk')
 
+const defaultErrorMessage = (methodName, bold) =>
+  `Expected test not to call ${bold(`console.${methodName}()`)}.\n\n` +
+  `If the ${methodName} is expected, test for it explicitly by mocking it out using ${bold(
+    'jest.spyOn'
+  )}(console, '${methodName}').mockImplementation() and test that the warning occurs.`
+
 const init = ({
   silenceMessage,
   shouldFailOnWarn = true,
   shouldFailOnError = true,
   shouldFailOnLog = false,
+  errorMessage = defaultErrorMessage,
 } = {}) => {
   const patchConsoleMethod = (methodName, unexpectedConsoleCallStacks) => {
     const newMethod = (format, ...args) => {
@@ -41,7 +48,7 @@ const init = ({
     // eslint-disable-next-line no-console
     if (console[methodName] !== mockMethod && !isSpy(console[methodName])) {
       throw new Error(`Test did not tear down console.${methodName} mock properly.
-    
+
     If you are trying to disable the "fail on console" mechanism, you should use beforeEach/afterEach
     instead of beforeAll/afterAll
     `)
@@ -63,11 +70,7 @@ const init = ({
         )
       })
 
-      const message =
-        `Expected test not to call ${chalk.bold(`console.${methodName}()`)}.\n\n` +
-        `If the ${methodName} is expected, test for it explicitly by mocking it out using ${chalk.bold(
-          'jest.spyOn'
-        )}(console, '${methodName}') and test that the warning occurs.`
+      const message = errorMessage(methodName, chalk.bold)
 
       throw new Error(`${message}\n\n${messages.join('\n\n')}`)
     }


### PR DESCRIPTION
As discussed in #11 , this PR adds support for custom error message. I also changed the default error message and added `mockImplementation` there, which should close #9.